### PR TITLE
BCL fixing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 install:
   - "pip install -r requirements.txt"
   - "pip install python-coveralls pytest-cov"
+  - "pip install coverage --upgrade"
   - "python setup.py install"
 
 script: PYTHONPATH=. py.test tests/ --cov EPPs --cov python_scripts --cov-report term-missing

--- a/fix_bcls.ps1
+++ b/fix_bcls.ps1
@@ -1,61 +1,75 @@
 
-function Fix-BCLs ($sourcePath, $destPath, $doCopy)
-{
-    Get-Location
-    Write-Output "source: $sourcePath"
-    Write-Output "dest: $destPath"
+function Fix-BCLs($sourcePath, $destPath, $doCopy) {
     if ($sourcePath.Name -ne $destPath.Name) {
         throw "Run ID in source and dest do not match"
     }
     
-    if (!(Test-Path -PathType Container $sourcePath) -and (Test-Path -PathType Container $destPath)) {
+    if (!((Test-Path -PathType Container $sourcePath) -and (Test-Path -PathType Container $destPath))) {
         throw "Missing source/dest directories"
     }
-
+    
     $bclValidationLog = "$destPath\checked_bcls.csv"
+    if ((Test-Path "$sourcePath\checked_bcls.csv") -or !(Test-Path $bclValidationLog)) {
+        throw "Source and dest directories seem to be swapped"
+    }
+
+    $logFile = "$destPath\fix_bcls.log"
+    
+    function Log($msg) {
+        $timeStamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+        $msg = "[$timeStamp] $msg"
+
+        Write-Output $msg
+        Add-Content $logFile -Value $msg
+    }
+    
+    Log "Source: $sourcePath"
+    Log "Dest: $destPath"
+    Log "Validation log: $bclValidationLog"
+
     $validationRecords = Get-Content -Path $bclValidationLog
+    $nBcls = 0
+    $nBclsFixed = 0
 
-    $bclsToFix = @()
-    foreach ($line in $validationRecords)
-    {
+    foreach ($line in $validationRecords) {
         $splitLine = $line -split ","
-        if ($splitLine[1] -notmatch "0") { $bclsToFix += $splitLine[0] }
-    }
-    $nBcls = $bclsToFix.Length
-    Write-Output "Fixing $nBcls bcls"
-    
-    foreach ($filePath in $bclsToFix) {
-        $filePath = $filePath -Split "/"
-        $lane = $filePath[0]
-        $cycle = $filePath[1]
-        $basename = $filePath[2]
-        
-        $sourceFile = "$sourcePath\Data\Intensities\BaseCalls\$lane\$cycle\$basename"
-        $destDir = "$destPath\Data\Intensities\BaseCalls\$lane\$cycle"
-        $destFile = "$destDir\$basename"
-        
-        if (!(($lane) -and ($cycle) -and ($basename) -and (Test-Path $sourceFile))) {
-            Write-Output "Found bad bcl file path in checked_bcls.csv: $sourceFile"
-            throw "Bad bcl file path"
-        }
 
-        Write-Output "Recopying $sourceFile to $destFile"
-        
-        if ($doCopy) {
-            if (!(Test-Path -PathType Container $destDir)) {
-                Write-Output "Missing container directory $destDir - creating"
-                New-Item -ItemType Directory $destDir
+        if ($splitLine[1] -notmatch "0") {
+            $filePath = $splitLine[0] -Split "/"
+            $lane = $filePath[0]
+            $cycle = $filePath[1]
+            $basename = $filePath[2]
+
+            $sourceFile = "$sourcePath\Data\Intensities\BaseCalls\$lane\$cycle\$basename"
+            $destDir = "$destPath\Data\Intensities\BaseCalls\$lane\$cycle"
+            $destFile = "$destDir\$basename"
+
+            if (!(($lane) -and ($cycle) -and ($basename) -and (Test-Path $sourceFile))) {
+                Log "Found bad bcl file path in checked_bcls.csv: $sourceFile"
+                throw "Bad bcl file path"
             }
-            Copy-Item $sourceFile $destFile
+
+            $nBclsFixed += 1
+            Log "Recopying $sourceFile to $destFile"
+
+            if ($doCopy) {
+                if (!(Test-Path -PathType Container $destDir)) {
+                    Log "Missing container directory $destDir - creating"
+                    New-Item -ItemType Directory $destDir
+                }
+                Copy-Item $sourceFile $destFile
+            }
         }
+        $nBcls += 1
     }
     
-    Write-Output "Fixed $nBcls bcls"    
+    Log "Found $nBcls bcls, fixed $nBclsFixed"    
     if (!($doCopy)) {
-        Write-Output "Dry run enabled - no files were copied"
+        Log "Dry run enabled - no files were copied"
     }
 }
 
+Write-Output "fix_bcls.ps1 - enter inputs as prompted, or ctrl-C to quit."
 $destPath = (Read-Host "Enter the path to the run to be fixed") | Get-Item
 $sourcePath = (Read-Host "Enter the path to the local backup copy of the run") | Get-Item
 $doCopy = (Read-Host "Enter 'Y' if file copying should be enabled (i.e, this is not a dry run)") -eq "Y"

--- a/fix_bcls.ps1
+++ b/fix_bcls.ps1
@@ -1,0 +1,63 @@
+
+function Fix-BCLs ($sourcePath, $destPath, $doCopy)
+{
+    Get-Location
+    Write-Output "source: $sourcePath"
+    Write-Output "dest: $destPath"
+    if ($sourcePath.Name -ne $destPath.Name) {
+        throw "Run ID in source and dest do not match"
+    }
+    
+    if (!(Test-Path -PathType Container $sourcePath) -and (Test-Path -PathType Container $destPath)) {
+        throw "Missing source/dest directories"
+    }
+
+    $bclValidationLog = "$destPath\checked_bcls.csv"
+    $validationRecords = Get-Content -Path $bclValidationLog
+
+    $bclsToFix = @()
+    foreach ($line in $validationRecords)
+    {
+        $splitLine = $line -split ","
+        if ($splitLine[1] -notmatch "0") { $bclsToFix += $splitLine[0] }
+    }
+    $nBcls = $bclsToFix.Length
+    Write-Output "Fixing $nBcls bcls"
+    
+    foreach ($filePath in $bclsToFix) {
+        $filePath = $filePath -Split "/"
+        $lane = $filePath[0]
+        $cycle = $filePath[1]
+        $basename = $filePath[2]
+        
+        $sourceFile = "$sourcePath\Data\Intensities\BaseCalls\$lane\$cycle\$basename"
+        $destDir = "$destPath\Data\Intensities\BaseCalls\$lane\$cycle"
+        $destFile = "$destDir\$basename"
+        
+        if (!(($lane) -and ($cycle) -and ($basename) -and (Test-Path $sourceFile))) {
+            Write-Output "Found bad bcl file path in checked_bcls.csv: $sourceFile"
+            throw "Bad bcl file path"
+        }
+
+        Write-Output "Recopying $sourceFile to $destFile"
+        
+        if ($doCopy) {
+            if (!(Test-Path -PathType Container $destDir)) {
+                Write-Output "Missing container directory $destDir - creating"
+                New-Item -ItemType Directory $destDir
+            }
+            Copy-Item $sourceFile $destFile
+        }
+    }
+    
+    Write-Output "Fixed $nBcls bcls"    
+    if (!($doCopy)) {
+        Write-Output "Dry run enabled - no files were copied"
+    }
+}
+
+$destPath = (Read-Host "Enter the path to the run to be fixed") | Get-Item
+$sourcePath = (Read-Host "Enter the path to the local backup copy of the run") | Get-Item
+$doCopy = (Read-Host "Enter 'Y' if file copying should be enabled (i.e, this is not a dry run)") -eq "Y"
+
+Fix-Bcls -sourcePath $sourcePath -destPath $destPath -doCopy $doCopy


### PR DESCRIPTION
Adds a PowerShell script to be run on a HiSeqX. Takes the checked_bcls.csv file from [Analysis-Driver](https://github.com/EdinburghGenomics/Analysis-Driver) and recopies any files with a non-zero validation exit status:

```
fix_bcls.ps1 - enter inputs as prompted, or ctrl-C to quit.
Enter the path to the run to be fixed: C:\path\to\shared_drive\run_id
Enter the path to the local backup copy of the run: D:\path\to\backup_drive\run_id
Enter 'Y' if file copying should be enabled (i.e, this is not a dry run): Y
[2018-12-14 14:20:30] Source: D:\path\to\backup_drive\run_id
[2018-12-14 14:20:30] Dest: C:\path\to\shared_drive\run_id
[2018-12-14 14:20:30] Validation log: C:\path\to\shared_drive\run_id\checked_bcls.csv
[2018-12-14 14:20:30] Recopying D:\path\to\backup_drive\run_id\Data\Intensities\BaseCalls\L001\C1.1\s_1_1102.bcl.gz to C:\path\to\shared_drive\run_id\Data\Intensities\BaseCalls\L001\C1.1\s_1_1102.bcl.gz
...
...
[2018-12-14 13:40:03] Found 1000 bcls, fixed 10
```

Closes #5.